### PR TITLE
Authenticate to azure via environment instead of branch

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -16,6 +16,7 @@ env:
 jobs:
   build-and-deploy-int:
     runs-on: windows-latest
+    environment: integration
     permissions:
       id-token: write
       contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,7 @@ env:
 jobs:
   build-and-deploy-prod:
     runs-on: windows-latest
+    environment: production
     name: Build and deploy to production
     permissions:
       id-token: write


### PR DESCRIPTION
- Switched federation type to environment, instead of branch. This is due to how actions are invoked with different contexts, creating a mismatch in what azure expects the request to look like. By adding the environment specifier to the workflows, the actions can now authenticate no matter how they're invoked.